### PR TITLE
Update Minecraft Wiki links to new domain

### DIFF
--- a/src/main/java/net/pistonmaster/serverwrecker/protocol/bot/utils/MapColorUtils.java
+++ b/src/main/java/net/pistonmaster/serverwrecker/protocol/bot/utils/MapColorUtils.java
@@ -82,7 +82,7 @@ public class MapColorUtils {
     }
 
     /**
-     * Keep in sync with: <a href="https://minecraft.fandom.com/wiki/Map_item_format?veaction=edit&section=8">Minecraft Fandom Page</a>
+     * Keep in sync with: <a href="https://minecraft.wiki/w/Map_item_format#Color_table">Minecraft Wiki Page</a>
      */
     private enum MapColor {
         NONE(0, 0, 0),


### PR DESCRIPTION
The Minecraft Fandom wiki has been forked to a new domain: minecraft.wiki. Learn more here: https://minecraft.wiki/w/Minecraft_Wiki:Moving_from_Fandom. This PR updates all URLs accordingly.